### PR TITLE
Fix command history navigation

### DIFF
--- a/src/CommandPrompt.svelte
+++ b/src/CommandPrompt.svelte
@@ -15,8 +15,8 @@
   });
 
   function navigateCommandHistory(step) {
-    currentCommandIndex = Math.max(0, Math.min(commandHistory.length - 1, currentCommandIndex + step));
-    commandInput = commandHistory[currentCommandIndex] || '';
+    currentCommandIndex = Math.max(-1, Math.min(commandHistory.length - 1, currentCommandIndex + step));
+    commandInput = currentCommandIndex === -1 ? '' : (commandHistory[currentCommandIndex] || '');
   }
 
   function previousCommand(e) {


### PR DESCRIPTION
## Summary
- allow arrow down to clear command prompt

## Testing
- `npm run build` *(fails: vite not found)*